### PR TITLE
change repo from jammy to noble because of https://gitlab.com/packagi…

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -84,7 +84,7 @@ runs:
     - name: Setup reprepro debian repository
       uses: myci-actions/add-deb-repo@11
       with:
-        repo: deb https://packaging.gitlab.io/reprepro-multiple-versions jammy main
+        repo: deb https://packaging.gitlab.io/reprepro-multiple-versions noble main
         repo-name: reprepro-multiple-versions
         keys-asc: https://packaging.gitlab.io/reprepro-multiple-versions/gpg.key
         update: true

--- a/import.sh
+++ b/import.sh
@@ -3,25 +3,25 @@
 set -e
 
 if [[ -z "${IMPORT_FROM_REPO}" ]]; then
-	echo "::notice title=Skipping::Skipping import"
-	exit 0
+    echo "::notice title=Skipping::Skipping import"
+    exit 0
 fi
 
 {
-	echo "set base_path ${APT_MIRROR_BASE_PATH:-/tmp/apt-mirror}"
-	echo "set run_postmirror 0"
-	echo -e "${IMPORT_FROM_REPO}"
+    echo "set base_path ${APT_MIRROR_BASE_PATH:-/tmp/apt-mirror}"
+    echo "set run_postmirror 0"
+    echo -e "${IMPORT_FROM_REPO}"
 } >/tmp/mirror.list
 apt-mirror /tmp/mirror.list |& tee /tmp/mirror.log
 if grep -q -i failed /tmp/mirror.log; then
-	cat /tmp/mirror.log
+    cat /tmp/mirror.log
     if [[ -z "${IMPORT_FROM_REPO_FAILURE_ALLOW}" ]]; then
-	    exit 1
+        exit 1
     fi
 fi
 mapfile -t packages < <(find /tmp/apt-mirror/mirror -type f -name '*.deb')
 # shellcheck disable=SC2128
 if [ -n "${packages}" ]; then
-	# shellcheck disable=SC2048,SC2086
-	cp -v ${packages[*]} .
+    # shellcheck disable=SC2048,SC2086
+    cp -v ${packages[*]} .
 fi


### PR DESCRIPTION
change repo from jammy to noble because of https://gitlab.com/packaging/reprepro-multiple-versions/-/commit/63e45110ae859b805052554a39ff6c09474e1064

```
Ign:8 https://packaging.gitlab.io/reprepro-multiple-versions jammy InRelease
Err:9 https://packaging.gitlab.io/reprepro-multiple-versions jammy Release
  404  Not Found [IP: 35.185.44.232 443]
Reading package lists...
E: The repository 'https://packaging.gitlab.io/reprepro-multiple-versions jammy Release' does not have a Release file.
Error: Process completed with exit code 100.
```